### PR TITLE
Organize roadmap tasks

### DIFF
--- a/docs/task_details/backtesting_framework.md
+++ b/docs/task_details/backtesting_framework.md
@@ -1,0 +1,5 @@
+# Backtesting Framework
+
+- [ ] Develop walk-forward testing loops using the configuration file.
+- [ ] Include realistic transaction costs and slippage.
+- [ ] Generate performance reports with plots.

--- a/docs/task_details/baseline_patchtst_model.md
+++ b/docs/task_details/baseline_patchtst_model.md
@@ -1,0 +1,5 @@
+# Baseline PatchTST Model
+
+- [ ] Build training module using PyTorch Lightning.
+- [ ] Support loading data from the feature pipeline.
+- [ ] Save trained checkpoints and training metrics.

--- a/docs/task_details/feature_engineering_pipeline.md
+++ b/docs/task_details/feature_engineering_pipeline.md
@@ -1,0 +1,6 @@
+# Feature Engineering Pipeline
+
+- [ ] Create a modular pipeline that reads `config.yaml` and generates features accordingly.
+- [ ] Implement order-flow feature generators.
+- [ ] Add NLP feature extraction using pretrained models.
+- [ ] Provide unit tests for feature generators.

--- a/docs/task_details/gpu_accelerated_deployment.md
+++ b/docs/task_details/gpu_accelerated_deployment.md
@@ -1,0 +1,5 @@
+# GPU-Accelerated Deployment
+
+- [ ] Package inference code for serving models with FastAPI.
+- [ ] Provide Dockerfile with CUDA support.
+- [ ] Add examples for running inference locally and in the cloud.

--- a/docs/task_details/nse_bse_data_connectors.md
+++ b/docs/task_details/nse_bse_data_connectors.md
@@ -1,0 +1,5 @@
+# NSE/BSE Data Connectors
+
+- [ ] Complete real-time streaming support for both exchanges.
+- [ ] Handle API authentication and rate limiting gracefully.
+- [ ] Persist raw data to Parquet/Arrow for reproducible backtests.

--- a/docs/task_details/paper_trading_integration.md
+++ b/docs/task_details/paper_trading_integration.md
@@ -1,0 +1,5 @@
+# Paper Trading Integration
+
+- [ ] Connect to broker APIs (e.g., Zerodha) in paper mode.
+- [ ] Implement risk management hooks for order sizing.
+- [ ] Log all trades for audit purposes.

--- a/docs/task_details/xlstm_ppo.md
+++ b/docs/task_details/xlstm_ppo.md
@@ -1,0 +1,5 @@
+# xLSTM-PPO Implementation
+
+- [ ] Implement the RL environment for intraday trading.
+- [ ] Integrate xLSTM policy and PPO algorithm.
+- [ ] Provide sample training script and evaluation metrics.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,0 +1,11 @@
+# Implementation Tasks
+
+This document provides an overview of the outstanding work for the project. Each section links to a file with detailed tasks so contributors can work on them independently.
+
+- [NSE/BSE Data Connectors](task_details/nse_bse_data_connectors.md)
+- [Feature Engineering Pipeline](task_details/feature_engineering_pipeline.md)
+- [Baseline PatchTST Model](task_details/baseline_patchtst_model.md)
+- [xLSTM-PPO Implementation](task_details/xlstm_ppo.md)
+- [Backtesting Framework](task_details/backtesting_framework.md)
+- [Paper Trading Integration](task_details/paper_trading_integration.md)
+- [GPU-Accelerated Deployment](task_details/gpu_accelerated_deployment.md)


### PR DESCRIPTION
## Summary
- restructure roadmap tasks into individual documents
- link tasks overview to detailed subtasks

## Testing
- `pytest -q` *(fails: command not found)*

## Summary by Sourcery

Organize the project’s roadmap tasks into a central overview document with links to individual subtask files and add separate detailed markdown documents for each roadmap task

Documentation:
- Create docs/tasks.md as an overview linking to detailed task documents
- Add individual markdown files under docs/task_details for each roadmap task (NSE/BSE Data Connectors, Feature Engineering Pipeline, Baseline PatchTST Model, xLSTM-PPO, Backtesting Framework, Paper Trading Integration, GPU-Accelerated Deployment)